### PR TITLE
Made navbar buttons unselectable

### DIFF
--- a/css/teaser.css
+++ b/css/teaser.css
@@ -85,6 +85,10 @@ body {
   height: 100px;
   margin: 0 auto;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .share-button, .share-toggle-button {


### PR DESCRIPTION
There is no reason for the buttons to be selectable, added a CSS
property that disallows selecting.
